### PR TITLE
Fix for Recursively bloated _current.json

### DIFF
--- a/bin/migration/make.js
+++ b/bin/migration/make.js
@@ -95,6 +95,7 @@ const make = async (argv) => {
 
   // save current state
   currentState.revision = previousState.revision + 1;
+  currentState.content = undefined; //deleting the earlier read content to avoid recursive content getting written
   fs.writeFileSync(currentState.path, JSON.stringify(currentState, null, 4));
 
   // eslint-disable-next-line import/no-dynamic-require

--- a/bin/migration/make.js
+++ b/bin/migration/make.js
@@ -95,7 +95,7 @@ const make = async (argv) => {
 
   // save current state
   currentState.revision = previousState.revision + 1;
-  currentState.content = undefined; //deleting the earlier read content to avoid recursive content getting written
+  currentState.content = undefined; // deleting the earlier read content to avoid recursive content getting written
   fs.writeFileSync(currentState.path, JSON.stringify(currentState, null, 4));
 
   // eslint-disable-next-line import/no-dynamic-require


### PR DESCRIPTION
Fix for issue #43 
The problem is created because of this `key:value` pair getting added in the `_current.json` file
```
"content": {
        "type": "Buffer",
        "data": [
            123,
            10,
            32,
            32,
            32,
            32,
            34,
            116,
            97,
            98,
            .....
            .....
            10,
            125
        ]
     }
```

The problem seems to be in `make.js`, 
Line 51 does this
```
currentState.content = fs.readFileSync(currentState.path);
```
This gets the buffered output in the `content` key.
And then later, after constructing the complete schema definition, we simply write it back to the `_current.json`
Line 98 does this
```
fs.writeFileSync(currentState.path, JSON.stringify(currentState, null, 4));
```
So all the binary content that was read earlier, gets re-written into the file, resulting in a massively bloated file and leading to `Migration:make running out of memory`
