### PR TITLE
support fn and literal

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -120,7 +120,8 @@ export const getDefaultValueType = (defaultValue, prefix = 'Sequelize.') => {
       const outerFnArgs = [JSON.stringify(innerFnName), ...innerFnArgs.map(arg => JSON.stringify(arg))]
       const stringifiedFunction = `${prefix}fn(${outerFnArgs.join(', ')})`
       return { internal: true, value: stringifiedFunction };
-    } else if (defaultValue.constructor.name === 'Literal') {
+    }
+    if (defaultValue.constructor.name === 'Literal') {
       const stringifiedFunction = `${prefix}literal(${JSON.stringify(defaultValue.val)})`
       return { internal: true, value: stringifiedFunction };
     }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -113,8 +113,20 @@ export const getColumnTypeName = (col, prefix = 'Sequelize.') => {
 };
 
 export const getDefaultValueType = (defaultValue, prefix = 'Sequelize.') => {
-  if (typeof defaultValue === 'object' && defaultValue.constructor && defaultValue.constructor.name)
+  if (typeof defaultValue === 'object' && defaultValue.constructor && defaultValue.constructor.name) {
+    if (defaultValue.constructor.name === 'Fn') {
+      const innerFnName = defaultValue.fn
+      const innerFnArgs = defaultValue.args
+      const outerFnArgs = [JSON.stringify(innerFnName), ...innerFnArgs.map(arg => JSON.stringify(arg))]
+      const stringifiedFunction = `${prefix}fn(${outerFnArgs.join(', ')})`
+      return { internal: true, value: stringifiedFunction };
+    } else if (defaultValue.constructor.name === 'Literal') {
+      const stringifiedFunction = `${prefix}literal(${JSON.stringify(defaultValue.val)})`
+      return { internal: true, value: stringifiedFunction };
+    }
+
     return { internal: true, value: prefix + defaultValue.constructor.name };
+  }
 
   if (typeof defaultValue === 'function') return { notSupported: true, value: '' };
 


### PR DESCRIPTION
Support defaultValues that are Sequelize.fn or Sequelize.literal
e.g.

in model:
```
import { Model, DataTypes, fn, literal } from 'sequelize';
...
id: {
    type: DataTypes.UUID,
    primaryKey: true,
    allowNull: false,
    defaultValue: literal('gen_random_uuid()')
}
```
results in migration file:
```
id: {
    type: Sequelize.UUID,
    field: 'id',
    defaultValue: Sequelize.literal('gen_random_uuid()'),
    allowNull: false,
    primaryKey: true
},
```
and current.json
```
"id": {
    "primaryKey": true,
    "allowNull": false,
    "defaultValue": {
        "internal": true,
        "value": "Sequelize.literal(\"gen_random_uuid()\")"
    },
    "field": "id",
    "seqType": "Sequelize.UUID"
},
```


and with fn (200 is just an example of how additional args of fn would get handled)

model:
```
import { Model, DataTypes, fn, literal } from 'sequelize';
...
created: {
    type: DataTypes.DATE,
    allowNull: false,
    defaultValue: fn('NOW', 200)
},
modified: {
    type: DataTypes.DATE,
    allowNull: false,
    defaultValue: fn('NOW')
},
```

migration:
```
created: {
      type: Sequelize.DATE,
      field: 'created',
      defaultValue: Sequelize.fn('NOW', 200),
      allowNull: false
  },
  modified: {
      type: Sequelize.DATE,
      field: 'modified',
      defaultValue: Sequelize.fn('NOW'),
      allowNull: false
  },
```

current.json
```
"created": {
    "allowNull": false,
    "defaultValue": {
        "internal": true,
        "value": "Sequelize.fn(\"NOW\", 200)"
    },
    "field": "created",
    "seqType": "Sequelize.DATE"
},
"modified": {
    "allowNull": false,
    "defaultValue": {
        "internal": true,
        "value": "Sequelize.fn(\"NOW\")"
    },
    "field": "modified",
    "seqType": "Sequelize.DATE"
},
```

and if you run the migration (not the one with NOW, 200) it results in the following in postgres:
```
CREATE TABLE public."XXX" (
    id uuid DEFAULT public.gen_random_uuid() NOT NULL,
    created timestamp with time zone DEFAULT now() NOT NULL,
    modified timestamp with time zone DEFAULT now() NOT NULL,
);
```
