### PR TITLE
feat: add auto-detection of potentially renamed columns

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -258,6 +258,21 @@ export const pathConfig = (options) => {
 export const readAsset = (assetPath) =>
   fs.readFileSync(join(dirname, './assets', assetPath)).toString();
 
+/**
+ * Slightly modified lodash groupBy
+ * https://github.com/lodash/lodash/blob/master/groupBy.js
+ */
+export const groupBy = (collection, iteratee) =>
+  collection.reduce((result, value, key) => {
+    key = iteratee(value);
+    if (Object.hasOwnProperty.call(result, key)) {
+      result[key].push(value);
+    } else {
+      result[key] = [value];
+    }
+    return result;
+  }, {});
+
 // #region new method for sorting actions / NEEDS More TESTING
 /*
   actions.sort((a, b) => {

--- a/lib/migration.js
+++ b/lib/migration.js
@@ -49,8 +49,12 @@ export const getPartialMigration = (actions) => {
       pars.push(par);
     }
 
-    if (addProperty) pars.push(stringifyModel(action.options));
-    pars.push(parseOptions(action.options, addTransaction));
+    if (action.actionType === 'renameColumn') {
+      pars.push(`"${action.options}"`);
+    } else {
+      if (addProperty) pars.push(stringifyModel(action.options));
+      pars.push(parseOptions(action.options, addTransaction));
+    }
 
     return `{
       fn: "${action.actionType}",
@@ -96,6 +100,7 @@ export const getPartialMigration = (actions) => {
         consolePar = commandPar;
         break;
 
+      case 'renameColumn':
       case 'removeColumn':
         commandPar = action.options.field ? action.options.field : action.columnName;
         consolePar = commandPar;
@@ -199,8 +204,9 @@ export const migrate = async (options) => {
     throw new Error(`sequelize index file is not valid probably. solve it and try again: ${e}`);
   }
 
-  const upActions = parseDifference(previousState.tables, currentState.tables);
-  const downActions = parseDifference(currentState.tables, previousState.tables);
+
+  const upActions = await parseDifference(previousState.tables, currentState.tables);
+  const downActions = await parseDifference(currentState.tables, previousState.tables, upActions);
 
   // sort actions
   sortActions(upActions);

--- a/lib/models.js
+++ b/lib/models.js
@@ -61,7 +61,7 @@ export const parseDifference = async (previousState, currentState, upActions = n
     });
   };
 
-  let initialDifferences = deepDiff.diff(previousState, currentState);
+  const initialDifferences = deepDiff.diff(previousState, currentState);
   if (!initialDifferences) return [];
 
   const possibleRenames = detectPossibleRenamedColumns(initialDifferences);

--- a/lib/models.js
+++ b/lib/models.js
@@ -1,6 +1,9 @@
 import deepDiff from 'deep-diff';
+import inquirer from 'inquirer';
+import hash from 'object-hash';
 
 import { parseAttributes, parseIndex } from './parser.js';
+import { groupBy } from './helpers.js';
 
 const { log } = console;
 
@@ -43,7 +46,7 @@ export const reverseModels = (sequelize, models) => {
   return tables;
 };
 
-export const parseDifference = (previousState, currentState) => {
+export const parseDifference = async (previousState, currentState, upActions = null) => {
   const loopIndexes = (diff, actionType, actions, actionTemplate, ArrayOfIndexes = false) => {
     Object.values(diff).forEach((index) => {
       if (ArrayOfIndexes) index = index[index];
@@ -58,10 +61,17 @@ export const parseDifference = (previousState, currentState) => {
     });
   };
 
-  const difference = deepDiff.diff(previousState, currentState);
-  if (!difference) return [];
+  let initialDifferences = deepDiff.diff(previousState, currentState);
+  if (!initialDifferences) return [];
 
-  const actions = [];
+  const possibleRenames = detectPossibleRenamedColumns(initialDifferences);
+
+  const [difference, actions] = await confirmRenamedColumns(
+    initialDifferences,
+    possibleRenames,
+    upActions,
+  );
+
 
   Object.values(difference).forEach((df) => {
     const action = { tableName: df.path[0], depends: [df.path[0]], options: {} };
@@ -192,4 +202,90 @@ export const parseDifference = (previousState, currentState) => {
     if (actionOptional.actionType) actions.push(actionOptional);
   });
   return actions;
+};
+
+/**
+ * Searches for columns that may have been renamed by
+ *
+ * - grouping all diffs by the table they belong to
+ * - finding all diffs that are removing or adding a row
+ * - check if there are a pair of add/remove diffs that, other than the name, have the same attributes
+ *
+ * @param {deepDiff.Diff[]} difference
+ */
+const detectPossibleRenamedColumns = (difference) => {
+
+  const diffsByTable = groupBy(difference, d => d.path[0]);
+
+  const possibleRenames = [];
+
+  Object.values(diffsByTable).forEach((diffs) => {
+    const deletedRows = diffs.filter(d => d.kind === 'D' && d.path.length === 3);
+    const addedRows = diffs.filter(d => d.kind === 'N' && d.path.length === 3);
+
+    // iterate over all of the deleted rows in the table
+    for (const deletedRow of deletedRows) {
+      // if there's an added row that has all the same attributes (other than the name) it's possibly a renamed row
+      const deletedRowHash = hash({ ...deletedRow.lhs, field: undefined });
+      const matchingAdd = addedRows.find(addedRow => deletedRowHash === hash({
+        ...addedRow.rhs,
+        field: undefined,
+      }));
+
+      if (matchingAdd) {
+        possibleRenames.push({ previous: deletedRow, current: matchingAdd });
+      }
+    }
+  });
+
+  return possibleRenames;
+};
+
+const confirmRenamedColumns = async (difference, possibleRenames, upActions) => {
+  const actions = [];
+
+  for (const possibleRename of possibleRenames) {
+    const { previous, current } = possibleRename;
+
+    const didConfirmRename = await promptIfColumnRenamed(possibleRename, upActions);
+    if (didConfirmRename) {
+      actions.push({
+        actionType: 'renameColumn',
+        tableName: current.path[0],
+        depends: [current.path[0]],
+        options: current.path[2],
+        columnName: previous.path[2],
+      });
+
+      // remove the addColumn and removeColumn actions
+      const kinds = [previous.kind, current.kind];
+      const fields = [previous.path[2], current.path[2]];
+      difference = difference.filter(d => d.path.length !== 3 || (!kinds.includes(d.kind) && !fields.includes(d.path[2])));
+    }
+  }
+  return [difference, actions];
+};
+
+const promptIfColumnRenamed = async ({ current, previous }, upActions) => {
+  if (!upActions) {
+    const { didRename } = await inquirer.prompt({
+      type: 'confirm',
+      name: 'didRename',
+      message: `Did you rename the ${current.path[0]} table field ${previous.lhs.field} to ${current.rhs.field}?`,
+    });
+    return didRename;
+  }
+  // don't ask the user again if we're computing the downActions, just check if the renameColumn action exists
+  return upActions.some(
+    ({
+       actionType,
+       tableName,
+       columnName,
+       options,
+     }) =>
+      actionType === 'renameColumn' &&
+      tableName === current.path[0] &&
+      columnName === current.path[2] &&
+      options === previous.path[2],
+  );
 };

--- a/lib/models.js
+++ b/lib/models.js
@@ -208,7 +208,7 @@ export const parseDifference = async (previousState, currentState, upActions = n
  * Searches for columns that may have been renamed by
  *
  * - grouping all diffs by the table they belong to
- * - finding all diffs that are removing or adding a row
+ * - finding all diffs that are removing or adding a column
  * - check if there are a pair of add/remove diffs that, other than the name, have the same attributes
  *
  * @param {deepDiff.Diff[]} difference
@@ -220,20 +220,20 @@ const detectPossibleRenamedColumns = (difference) => {
   const possibleRenames = [];
 
   Object.values(diffsByTable).forEach((diffs) => {
-    const deletedRows = diffs.filter(d => d.kind === 'D' && d.path.length === 3);
-    const addedRows = diffs.filter(d => d.kind === 'N' && d.path.length === 3);
+    const deletedColumns = diffs.filter(d => d.kind === 'D' && d.path.length === 3);
+    const addedColumns = diffs.filter(d => d.kind === 'N' && d.path.length === 3);
 
-    // iterate over all of the deleted rows in the table
-    for (const deletedRow of deletedRows) {
-      // if there's an added row that has all the same attributes (other than the name) it's possibly a renamed row
-      const deletedRowHash = hash({ ...deletedRow.lhs, field: undefined });
-      const matchingAdd = addedRows.find(addedRow => deletedRowHash === hash({
-        ...addedRow.rhs,
+    // iterate over all of the deleted columns in the table
+    for (const deletedColumn of deletedColumns) {
+      // if there's an added column that has all the same attributes (other than the name) it's possibly a renamed column
+      const deletedColumnHash = hash({ ...deletedColumn.lhs, field: undefined });
+      const matchingAdd = addedColumns.find(addedColumn => deletedColumnHash === hash({
+        ...addedColumn.rhs,
         field: undefined,
       }));
 
       if (matchingAdd) {
-        possibleRenames.push({ previous: deletedRow, current: matchingAdd });
+        possibleRenames.push({ previous: deletedColumn, current: matchingAdd });
       }
     }
   });
@@ -271,7 +271,7 @@ const promptIfColumnRenamed = async ({ current, previous }, upActions) => {
     const { didRename } = await inquirer.prompt({
       type: 'confirm',
       name: 'didRename',
-      message: `Did you rename the ${current.path[0]} table field ${previous.lhs.field} to ${current.rhs.field}?`,
+      message: `Did you rename the ${current.path[0]} table column "${previous.lhs.field}" to "${current.rhs.field}"?`,
     });
     return didRename;
   }

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
   ],
   "dependencies": {
     "deep-diff": "^1.0.2",
+    "inquirer": "^8.0.0",
     "object-hash": "^2.1.1",
     "prettier": "^2.2.1",
     "sequelize": "^6.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4400,6 +4400,25 @@ inquirer@^7.0.0:
     strip-ansi "^6.0.0"
     through "^2.3.6"
 
+inquirer@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.0.0.tgz#957a46db1abcf0fdd2ab82deb7470e90afc7d0ac"
+  integrity sha512-ON8pEJPPCdyjxj+cxsYRe6XfCJepTxANdNnTebsTuQgXpRyZRRT9t4dJwjRubgmvn20CLSEnozRUayXyM9VTXA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.6"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
 into-stream@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/into-stream/-/into-stream-5.1.1.tgz#f9a20a348a11f3c13face22763f2d02e127f4db8"
@@ -5695,6 +5714,11 @@ lodash@^4.16.4, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.
   version "4.17.20"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+
+lodash@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 lodash@~1.3.1:
   version "1.3.1"
@@ -7611,6 +7635,13 @@ rxjs@^6.6.0:
   version "6.6.2"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.2.tgz#8096a7ac03f2cc4fe5860ef6e572810d9e01c0d2"
   integrity sha512-BHdBMVoWC2sL26w//BCu3YzKT4s2jip/WhwsGEDmeKYBhKDZeYezVUnHatYB7L85v5xs0BAQmg6BEYJEKxBabg==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.6:
+  version "6.6.6"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.6.tgz#14d8417aa5a07c5e633995b525e1e3c0dec03b70"
+  integrity sha512-/oTwee4N4iWzAMAL9xdGKjkEHmIwupR3oXbQjCKywF1BeFohswF3vZdogbmEF6pZkOsXTzWkrZszrWpQTByYVg==
   dependencies:
     tslib "^1.9.0"
 


### PR DESCRIPTION
This PR adds functionality to detect if a migration contains potentially renamed columns.  It does this by:

- grouping all diffs by the table they belong to
- finding all diffs that are removing or adding a row
- checking if there are a pair of add/remove diffs that, other than the name, have the same attributes

If a potential column rename is detected the user is then asked if it's actually a rename.  If yes, then a `columnRename` action is added and the add/remove diffs are removed.

![image](https://user-images.githubusercontent.com/27715246/109427020-0f24a280-79b6-11eb-88e5-e6d67f690e0a.png)



